### PR TITLE
Prevent anonymous volume creation.

### DIFF
--- a/1-Hello-World/.gitignore
+++ b/1-Hello-World/.gitignore
@@ -1,0 +1,1 @@
+/volumes/

--- a/1-Hello-World/docker-compose.yml
+++ b/1-Hello-World/docker-compose.yml
@@ -1,9 +1,12 @@
 services:
     broker:
         image: rabbitmq:3.11-management
+        hostname: oryctolagus
         ports:
             - "5672:5672"
             - "15672:15672"
+        volumes:
+            - ./volumes/broker_data:/var/lib/rabbitmq
     producer:
         image: mcr.microsoft.com/dotnet/sdk:6.0
         working_dir: /source

--- a/2-Work-queues/.gitignore
+++ b/2-Work-queues/.gitignore
@@ -1,0 +1,1 @@
+/volumes/

--- a/2-Work-queues/docker-compose.yml
+++ b/2-Work-queues/docker-compose.yml
@@ -1,9 +1,12 @@
 services:
     broker:
         image: rabbitmq:3.11-management
+        hostname: oryctolagus
         ports:
             - "5672:5672"
             - "15672:15672"
+        volumes:
+            - ./volumes/broker_data:/var/lib/rabbitmq
     producer:
         image: mcr.microsoft.com/dotnet/sdk:6.0
         working_dir: /source

--- a/3-Publish-Subscribe/.gitignore
+++ b/3-Publish-Subscribe/.gitignore
@@ -1,0 +1,1 @@
+/volumes/

--- a/3-Publish-Subscribe/docker-compose.yml
+++ b/3-Publish-Subscribe/docker-compose.yml
@@ -1,9 +1,12 @@
 services:
     broker:
         image: rabbitmq:3.11-management
+        hostname: oryctolagus
         ports:
             - "5672:5672"
             - "15672:15672"
+        volumes:
+            - ./volumes/broker_data:/var/lib/rabbitmq
     producer:
         image: mcr.microsoft.com/dotnet/sdk:6.0
         working_dir: /source


### PR DESCRIPTION
**This branch is deliberately not complete. It should not be merged as is.**

Please test the behaviour of `docker compose` (I have tested `docker-compose`) and describe the behaviour in a comment. I will then tidy up the commit message for the sole commit in this Pull Request and re-submit it.

<hr>

The broker image declares a `VOLUME` for `/var/lib/rabbitmq`, see
`docker history --format='{{.CreatedBy}}' rabbitmq:3.11-management`

A new anonymous volume will be created every time a new broker container is created unless this directory is mounted using either a named volume or a bind mount.

When the broker container is destroyed, e.g. by
`docker-compose down`
the anonymous volume remains. Several cycles of alternate
`docker-compose up`
and
`docker-compose down`
will create and then destroy a series of broker containers, each leaving behind another anonymous volume.

Note: the broker container is not destroyed when using Ctrl+C to exit gracefully from
`docker-compose up`

This can be verified using
`docker container ls --all --format 'table {{.Names}}\t{{.Status}}'`
which should show that the broker container exists and is stopped.

[TODO: Do repeated
`docker compose up`
and
`docker compose down`
cycles have the same behaviour?

Use
`docker compose up --no-start`
and
`docker inspect --format '{{json .Mounts}}' <container_name>`
e.g.
`docker inspect --format '{{json .Mounts}}' 2-work-queues_broker_1`
to confirm that the anonymous volume is created when the container is created, i.e. before the container is started.

Use
`docker container ls --all --format 'table {{.Names}}\t{{.Status}}'`
to confirm that the container has been created but not started.

Then use
`docker compose up`
without the `--no-start` option to start the containers created previously.

Perhaps define a shell function to view the contents of a volume:
`view_volume() { docker run --rm -v "$1":/mnt/data alpine:3.17.3 find /mnt/data -maxdepth 2 -print; }`
Usage:
`view_volume <volume_name>`
e.g. for an anonymous volume identified by a generated name
`view_volume fedcba98765432100123456789abcdeffedcba98765432100123456789abcdef`

The shell function can be used to verify that the given anonymous volume contains RabbitMQ data.
]